### PR TITLE
feat(back-office) : CRUD User & Company

### DIFF
--- a/src/Controller/Back/AdminCompanyController.php
+++ b/src/Controller/Back/AdminCompanyController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\Company;
+use App\Form\AdminCompanyType;
+use App\Form\AdminFilterType;
+use App\Form\CustomSearchFormType;
+use App\Repository\UserRepository;
+use App\Repository\CompanyRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/company')]
+#[Security('is_granted("ROLE_ADMIN")')]
+class AdminCompanyController extends AbstractController
+{
+    #[Route('/', name: 'app_company_index', methods: ['GET', 'POST'])]
+    public function index(Request $request, CompanyRepository $companyRepository, SessionInterface $session): Response
+    {
+        # Get all company (even not active)
+        $companies = $companyRepository->findAll();
+
+        //Search Company
+        $searchForm = $this->createForm(CustomSearchFormType::class);
+        $searchForm->handleRequest($request);
+
+        if ($searchForm->isSubmitted() && $searchForm->isValid()) {
+            $searchTerm = strtolower($searchForm->get('search')->getData());
+            $companies = $companyRepository->searchCompanyByNameOrEmailOrPhone($searchTerm);
+        }
+
+        //Status filter
+        $filterForm = $this->createForm(AdminFilterType::class);
+        $filterForm->handleRequest($request);
+
+        if ($filterForm->isSubmitted() && $filterForm->isValid()) {
+            $status = $filterForm->get('status')->getData();
+            if ($status) $companies = $companyRepository->filterCompaniesByStatus($status);
+        }
+
+        return $this->render('back/company/index.html.twig', [
+            'companies' => $companies,
+            'filterForm' => $filterForm,
+            'searchForm' => $searchForm,
+            'errors' => $session->getFlashBag()->get('error', []),
+            'success' => $session->getFlashBag()->get('success', [])
+        ]);
+    }
+
+    #[Route('/new', name: 'app_company_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        $company = new Company();
+        $form = $this->createForm(AdminCompanyType::class, $company);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // Get datas from form
+            $formData = $form->getData();
+            $connectedUser = $this->getUser();
+
+            // Company
+            $company
+                ->setName($formData->getName())
+                ->setAddress($formData->getAddress())
+                ->setEmail($formData->getEmail())
+                ->setPhone($formData->getPhone())
+                ->setUpdatedBy($connectedUser->getId())
+                ->setCreatedBy($connectedUser->getId());
+
+            $entityManager->persist($company);
+            $entityManager->flush();
+
+            $session->getFlashBag()->add('success', "La company a bien été créée.");
+            return $this->redirectToRoute('back_app_company_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('back/company/new.html.twig', [
+            'company' => $company,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_company_show', methods: ['GET'])]
+    public function show(Company $company, UserRepository $userRepository): Response
+    {
+        $createdByUser = $userRepository->find($company->getCreatedBy());
+        $createdBy = $createdByUser ? ['name' => $createdByUser->getDisplayName()] : ['name' => ''];
+        return $this->render('back/company/show.html.twig', [
+            'company' => $company,
+            'created_by' => $createdBy,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_company_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, Company $company, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        $form = $this->createForm(AdminCompanyType::class, $company);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // Get datas from form
+            $formData = $form->getData();
+            $connectedUser = $this->getUser();
+
+            // Company
+            $company
+                ->setName($formData->getName())
+                ->setAddress($formData->getAddress())
+                ->setEmail($formData->getEmail())
+                ->setPhone($formData->getPhone())
+                ->setUpdatedBy($connectedUser->getId())
+                ->setCreatedBy($connectedUser->getId());
+
+            $entityManager->flush();
+            $session->getFlashBag()->add('success', "La company a bien été modifiée.");
+            return $this->redirectToRoute('back_app_company_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('back/company/edit.html.twig', [
+            'company' => $company,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_company_delete', methods: ['POST'])]
+    public function delete(Request $request, Company $company, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        if ($this->isCsrfTokenValid('delete'.$company->getId(), $request->request->get('_token'))) {
+            if($company->isIsDeleted()){
+                $session->getFlashBag()->add('error', "La company a déjà été supprimée.");
+            } else {
+                $company->setIsDeleted(true);
+                $entityManager->flush();
+                $session->getFlashBag()->add('success', "La company a bien été supprimée.");
+            }
+        }
+
+        return $this->redirectToRoute('back_app_company_index', [], Response::HTTP_SEE_OTHER);
+    }
+
+    #[Route('/{id}/enable', name: 'app_company_enable', methods: ['POST'])]
+    public function enable(Request $request, Company $company, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        if ($this->isCsrfTokenValid('enable'.$company->getId(), $request->request->get('_token'))) {
+            if($company->isIsDeleted()){
+                $company->setIsDeleted(false);
+                $entityManager->flush();
+                $session->getFlashBag()->add('success', "La company a bien été réactivée.");
+            } else {
+                $session->getFlashBag()->add('error', "La company a déjà été réactivée.");
+            }
+        }
+
+        return $this->redirectToRoute('back_app_company_index', [], Response::HTTP_SEE_OTHER);
+    }
+}

--- a/src/Controller/Back/AdminUserController.php
+++ b/src/Controller/Back/AdminUserController.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\User;
+use App\Form\AdminUserType;
+use App\Form\AdminFilterType;
+use App\Form\CustomSearchFormType;
+use App\Service\MailService;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[Route('/user')]
+#[Security('is_granted("ROLE_ADMIN")')]
+class AdminUserController extends AbstractController
+{
+    #[Route('/', name: 'app_user_index', methods: ['GET', 'POST'])]
+    public function index(Request $request, UserRepository $userRepository, SessionInterface $session): Response
+    {
+        // Get all users even not active excepted the admin logged (because update in settings page).
+        $users = $userRepository->findAllUsersWithoutLoggedAdmin($this->getUser()->getId());
+
+        //Search User
+        $searchForm = $this->createForm(CustomSearchFormType::class);
+        $searchForm->handleRequest($request);
+
+        if ($searchForm->isSubmitted() && $searchForm->isValid()) {
+            $searchTerm = strtolower($searchForm->get('search')->getData());
+            $users = $userRepository->searchUserByNameOrEmailOrCompanyName($this->getUser()->getId(), $searchTerm);
+        }
+
+        //Status filter
+        $filterForm = $this->createForm(AdminFilterType::class);
+        $filterForm->handleRequest($request);
+
+        if ($filterForm->isSubmitted() && $filterForm->isValid()) {
+            $status = $filterForm->get('status')->getData();
+            if ($status) $users = $userRepository->filterUsersByStatus($this->getUser()->getId(), $status);
+        }
+        
+        return $this->render('back/user/index.html.twig', [
+            'users' => $users,
+            'filterForm' => $filterForm,
+            'searchForm' => $searchForm,
+            'errors' => $session->getFlashBag()->get('error', []),
+            'success' => $session->getFlashBag()->get('success', [])
+        ]);
+    }
+
+    #[Route('/new', name: 'app_user_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $entityManager, SessionInterface $session, UserPasswordHasherInterface $passwordHasher): Response
+    {
+        $user = new User();
+        $form = $this->createForm(AdminUserType::class, $user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // Get datas from form
+            $formData = $form->getData();
+            $connectedUser = $this->getUser();
+
+            // Generate random password for user.
+            $newPassword = bin2hex(random_bytes(8));
+            $hashedPassword = $passwordHasher->hashPassword($user, $newPassword);
+            $user->setPassword($hashedPassword);
+
+            // User
+            $user
+                ->setFirstName($formData->getFirstName())
+                ->setLastName($formData->getFirstName())
+                ->setEmail($formData->getEmail())
+                ->setPassword($hashedPassword)
+                ->setCompany($formData->getCompany())
+                ->setRoles([$form->get('role')->getData()])
+                ->setUpdatedBy($connectedUser->getId())
+                ->setCreatedBy($connectedUser->getId());
+
+            $entityManager->persist($user);
+            $entityManager->flush();
+
+            $session->getFlashBag()->add('success', "L'utilisateur a bien été crée.");
+            return $this->redirectToRoute('back_app_user_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('back/user/new.html.twig', [
+            'user' => $user,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_user_show', methods: ['GET'])]
+    public function show(User $user, UserRepository $userRepository, SessionInterface $session): Response
+    {
+        $createdByUser = $userRepository->find($user->getCreatedBy());
+        $createdBy = $createdByUser ? ['name' => $createdByUser->getDisplayName()] : ['name' => ''];
+        return $this->render('back/user/show.html.twig', [
+            'user' => $user,
+            'created_by' => $createdBy,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_user_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, User $user, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        $user_roles = $user->getRoles();
+
+        if (in_array('ROLE_ADMIN', $user_roles)) {
+            $highestRole = 'ROLE_ADMIN';
+        } elseif (in_array('ROLE_COMPANY', $user_roles)) {
+            $highestRole = 'ROLE_COMPANY';
+        } elseif (in_array('ROLE_ACCOUNTANT', $user_roles)) {
+            $highestRole = 'ROLE_ACCOUNTANT';
+        } else {
+            $highestRole = 'ROLE_COMPANY'; // Default
+        }
+
+        $form = $this->createForm(AdminUserType::class, $user, [
+            'highest_role' => $highestRole,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // Get datas from form
+            $formData = $form->getData();
+            $connectedUser = $this->getUser();
+
+            // User
+            $user
+                ->setFirstName($formData->getFirstName())
+                ->setLastName($formData->getFirstName())
+                ->setEmail($formData->getEmail())
+                ->setCompany($formData->getCompany())
+                ->setRoles([$form->get('role')->getData()])
+                ->setUpdatedBy($connectedUser->getId());
+
+            $entityManager->flush();
+            $session->getFlashBag()->add('success', "L'utilisateur a bien été modifié.");
+            return $this->redirectToRoute('back_app_user_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->render('back/user/edit.html.twig', [
+            'user' => $user,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_user_delete', methods: ['POST'])]
+    public function delete(Request $request, User $user, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        if ($this->isCsrfTokenValid('delete'.$user->getId(), $request->request->get('_token'))) {
+            if($user->isIsDeleted()){
+                $session->getFlashBag()->add('error', "L'utilisateur a déjà été supprimée.");
+            } else {
+                $user->setIsDeleted(true);
+                $entityManager->flush();
+                $session->getFlashBag()->add('success', "L'utilisateur a bien été supprimée.");
+            }
+        }
+
+        return $this->redirectToRoute('back_app_user_index', [], Response::HTTP_SEE_OTHER);
+    }
+
+    #[Route('/{id}/enable', name: 'app_user_enable', methods: ['POST'])]
+    public function enable(Request $request, User $user, EntityManagerInterface $entityManager, SessionInterface $session): Response
+    {
+        if ($this->isCsrfTokenValid('enable'.$user->getId(), $request->request->get('_token'))) {
+            if($user->isIsDeleted()){
+                $user->setIsDeleted(false);
+                $entityManager->flush();
+                $session->getFlashBag()->add('success', "L'utilisateur a bien été réactivé.");
+            } else {
+                $session->getFlashBag()->add('error', "L'utilisateur a déjà été réactivé.");
+            }
+        }
+
+        return $this->redirectToRoute('back_app_user_index', [], Response::HTTP_SEE_OTHER);
+    }
+
+    #[Route('/{id}/send-mail', name: 'app_user_send_mail', methods: ['POST'])]
+    public function send_mail(Request $request, User $user, EntityManagerInterface $entityManager, SessionInterface $session, MailService $mailService, UserPasswordHasherInterface $passwordHasher, UrlGeneratorInterface $urlGenerator): Response
+    {
+        if ($this->isCsrfTokenValid('send_mail'.$user->getId(), $request->request->get('_token'))) {
+            if($user->isIsDeleted()){
+                $session->getFlashBag()->add('error', "Vous ne pouvez pas envoyer de mail à un utilisateur supprimé.");
+            } else {
+                // Generate new password for user in order to send it an readable one in email.
+                $newPassword = bin2hex(random_bytes(8));
+                $hashedPassword = $passwordHasher->hashPassword($user, $newPassword);
+                $user->setPassword($hashedPassword);
+
+                $loginUrl = $urlGenerator->generate('app_login', [], UrlGeneratorInterface::ABSOLUTE_URL);
+                try {
+                    $mailService->sendTemplatedEmail(
+                        $user->getEmail(),
+                        'Votre nouveau compte | Clickbill',
+                        'emails/new_account.html.twig',
+                        [
+                            'loginEmail' => $user->getEmail(),
+                            'loginPassword' => $newPassword,
+                            'loginUrl' => $loginUrl,
+                        ]
+                    );
+
+                    $entityManager->flush();
+                    $session->getFlashBag()->add('success', "L'email de connexion à bien été envoyé.");
+                } catch (\Exception $exception) {
+                    $session->getFlashBag()->add('error', "Une erreur est survenu lors de l'envoi du mail de connexion à l'utilisateur.");
+                }
+            }
+        }
+
+        return $this->redirectToRoute('back_app_user_index', [], Response::HTTP_SEE_OTHER);
+    }
+}

--- a/src/Controller/Front/Company/ProductController.php
+++ b/src/Controller/Front/Company/ProductController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/product')]
-#[Security('is_granted("ROLE_USER")')]
+#[Security('is_granted("ROLE_COMPANY")')]
 class ProductController extends AbstractController
 {
     #[Route('/', name: 'app_product_index', methods: ['GET', 'POST'])]

--- a/src/Controller/Public/RegistrationController.php
+++ b/src/Controller/Public/RegistrationController.php
@@ -20,8 +20,15 @@ class RegistrationController extends AbstractController
     public function register(Request $request, MailService $mailService): Response
     {
         if ($this->getUser()) {
-            # TODO : Redirect to another route according the role.
-            return $this->redirectToRoute('front_company_app_dashboard');
+            if (in_array('ROLE_ADMIN', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('back_app_dashboard');
+            }
+            if (in_array('ROLE_COMPANY', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_company_app_dashboard');
+            }
+            if (in_array('ROLE_ACCOUNTANT', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_accountant_app_dashboard');
+            }
         }
 
         $form = $this->createForm(RegistrationFormType::class);
@@ -61,8 +68,15 @@ class RegistrationController extends AbstractController
     public function resetPassword(Request $request, MailService $mailService, EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher): Response
     {
         if ($this->getUser()) {
-            # TODO : Redirect to another route according the role.
-            return $this->redirectToRoute('front_app_company_dashboard');
+            if (in_array('ROLE_ADMIN', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('back_app_dashboard');
+            }
+            if (in_array('ROLE_COMPANY', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_company_app_dashboard');
+            }
+            if (in_array('ROLE_ACCOUNTANT', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_accountant_app_dashboard');
+            }
         }
 
         $form = $this->createForm(ResetPasswordFormType::class);

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -15,8 +15,15 @@ class SecurityController extends AbstractController
     public function login(AuthenticationUtils $authenticationUtils, EntityManagerInterface $entityManager): Response
     {
         if ($this->getUser()) {
-            # TODO : Redirect to another page according the role.
-            return $this->redirectToRoute('front_company_app_dashboard');
+            if (in_array('ROLE_ADMIN', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('back_app_dashboard');
+            }
+            if (in_array('ROLE_COMPANY', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_company_app_dashboard');
+            }
+            if (in_array('ROLE_ACCOUNTANT', $this->getUser()->getRoles())) {
+                return $this->redirectToRoute('front_accountant_app_dashboard');
+            }
         }
 
         // get the login error if there is one

--- a/src/DataFixtures/ClientFixtures.php
+++ b/src/DataFixtures/ClientFixtures.php
@@ -30,8 +30,7 @@ class ClientFixtures extends Fixture
       ->setAddress('Test adresse')
       ->setPhone('1234567')
       ->setEmail('test@gmail.com')
-      ->setCreatedBy(1)
-      ->setCreatedAt(new \DateTime('now'));
+      ->setCreatedBy(1);
 
     //Create a company user
     $user = (new User())

--- a/src/DataFixtures/ProductFixtures.php
+++ b/src/DataFixtures/ProductFixtures.php
@@ -19,8 +19,7 @@ class ProductFixtures extends Fixture {
             ->setPhone('0645872332')
             ->setEmail('testforproducts@user.fr')
             ->setLogo('logo.png')
-            ->setCreatedBy(1)
-            ->setCreatedAt(new \DateTime('now'));
+            ->setCreatedBy(1);
         $manager->persist($company1);
 
         $company2 = (new Company())
@@ -29,8 +28,7 @@ class ProductFixtures extends Fixture {
             ->setPhone('0645872333')
             ->setEmail('testforproducts2@user.fr')
             ->setLogo('logo.png')
-            ->setCreatedBy(1)
-            ->setCreatedAt(new \DateTime('now'));
+            ->setCreatedBy(1);
         $manager->persist($company2);
 
         $category1 = new Category();

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -39,8 +39,7 @@ class UserFixtures extends Fixture
             ->setPhone('0654326494')
             ->setEmail('company@user.fr')
             ->setLogo('logo.png')
-            ->setCreatedBy($company_user->getId())
-            ->setCreatedAt(new \DateTime('now'));
+            ->setCreatedBy($company_user->getId());
         $manager->persist($company);
         $manager->flush();
 

--- a/src/Entity/Company.php
+++ b/src/Entity/Company.php
@@ -5,13 +5,17 @@ namespace App\Entity;
 use App\Repository\CompanyRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints\Unique;
 
 #[ORM\Entity(repositoryClass: CompanyRepository::class)]
+#[UniqueEntity(fields: ['name'], message: 'Une company avec ce nom est déjà existante.')]
 class Company
 {
+    use Traits\Timestampable;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -35,14 +39,8 @@ class Company
     #[ORM\Column]
     private ?int $createdBy = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
-
     #[ORM\Column(nullable: true)]
     private ?int $updatedBy = null;
-
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?\DateTimeInterface $updatedAt = null;
 
     #[ORM\Column]
     private ?bool $isDeleted = false;
@@ -145,18 +143,6 @@ class Company
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
-    {
-        return $this->createdAt;
-    }
-
-    public function setCreatedAt(\DateTimeInterface $createdAt): static
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
     public function getUpdatedBy(): ?int
     {
         return $this->updatedBy;
@@ -165,18 +151,6 @@ class Company
     public function setUpdatedBy(int $updatedBy): static
     {
         $this->updatedBy = $updatedBy;
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): ?\DateTimeInterface
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(?\DateTimeInterface $updatedAt): static
-    {
-        $this->updatedAt = $updatedAt;
 
         return $this;
     }

--- a/src/Form/AdminCompanyType.php
+++ b/src/Form/AdminCompanyType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Company;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TelType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
+
+class AdminCompanyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length(['max' => 255]),
+                ],
+            ])
+            ->add('email', EmailType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Le champ email ne peut pas être vide.']),
+                    new Email(['message' => "L'adresse email est invalide."])
+                ],
+            ])
+            ->add('phone', TelType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Le numéro de téléphone ne peut pas être vide.']),
+                    new Regex([
+                        'pattern' => '/^[0-9+\-() ]*$/',
+                        'message' => "Le numéro de téléphone n'est pas valide.",
+                    ]),
+                    new Length([
+                        'min' => 5,
+                        'max' => 15,
+                        'minMessage' => 'Le numéro de téléphone doit avoir au moins {{ limit }} caractères.',
+                        'maxMessage' => 'Le numéro de téléphone ne peut pas avoir plus de {{ limit }} caractères.',
+                    ]),
+                ],
+            ])
+            ->add('address', TextType::class, [
+                'constraints' => [
+                    new NotBlank(),
+                    new Length([
+                        'max' => 128,
+                        'maxMessage' => 'L\'adresse ne peut pas avoir plus de {{ limit }} caractères.'
+                    ]),
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Company::class,
+        ]);
+    }
+}

--- a/src/Form/AdminFilterType.php
+++ b/src/Form/AdminFilterType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Choice;
+
+class AdminFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+        ->add('status', ChoiceType::class, [
+        'choices' => [
+            'Actif' => 'true',
+            'Inactif' => 'false',
+            ],
+            'label' => false,
+            'placeholder' => 'Statut',
+            'attr' => [
+                'id' => 'filter-select',
+                'class' => '
+                    flex-shrink-0 z-10 inline-flex items-center py-2.5 px-4 text-sm font-medium text-center border rounded-s-lg
+                    bg-neutral-100 text-neutral-900 border-neutral-300 focus:ring-0 focus:border-neutral-300
+                    dark:bg-neutral-700 dark:text-neutral-200 dark:border-neutral-700
+                ',
+            ],
+        ])
+        ->add('submit', SubmitType::class, [
+            'label' => false,
+            'attr' => [
+            'class' => 'hidden',
+            ],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+        // Configure your form options here
+        ]);
+    }
+}

--- a/src/Form/AdminUserType.php
+++ b/src/Form/AdminUserType.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Company;
+use App\Entity\User;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AdminUserType extends AbstractType
+{
+    private $roleDisplayNames = [
+        'ROLE_ADMIN' => 'Admin',
+        'ROLE_ACCOUNTANT' => 'Comptable',
+        'ROLE_COMPANY' => 'Entreprise',
+    ];
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $choices = [];
+        foreach ($this->roleDisplayNames as $role => $displayName) {
+            $choices[$displayName] = $role;
+        }
+        $builder
+            ->add('firstName', TextType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Veuillez entrer un prénom.']),
+                    new Length([
+                        'min' => 2,
+                        'max' => 32,
+                        'minMessage' => 'Le prénom doit contenir au moins {{ limit }} caractères.',
+                        'maxMessage' => 'Le prénom ne peut pas contenir plus de {{ limit }} caractères.',
+                    ]),
+                    new Regex([
+                        'pattern' => '/^\p{L}+$/u',
+                        'message' => 'Le prénom ne peut contenir que des lettres.',
+                    ]),
+                ],
+            ])
+            ->add('lastName', TextType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Veuillez entrer un nom.']),
+                    new Length([
+                        'min' => 2,
+                        'max' => 32,
+                        'minMessage' => 'Le nom doit contenir au moins {{ limit }} caractères.',
+                        'maxMessage' => 'Le nom ne peut pas contenir plus de {{ limit }} caractères.',
+                    ]),
+                    new Regex([
+                        'pattern' => '/^\p{L}+$/u',
+                        'message' => 'Le nom ne peut contenir que des lettres.',
+                    ]),
+                ],
+            ])
+            ->add('email', EmailType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Le champ email ne peut pas être vide.']),
+                    new Email(['message' => "L'adresse email est invalide."]),
+                ],
+            ])
+            ->add('role', ChoiceType::class, [
+                'choices' => $choices,
+                'multiple' => false,
+                'mapped' => false,
+                'data' => $options['highest_role'] ?? 'ROLE_COMPANY'
+            ])
+            ->add('company', EntityType::class, [
+                'class' => Company::class,
+                'choice_label' => 'name',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+            'highest_role' => 'ROLE_COMPANY'
+        ]);
+    }
+}

--- a/src/Repository/CompanyRepository.php
+++ b/src/Repository/CompanyRepository.php
@@ -40,6 +40,40 @@ class CompanyRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+    * @return Company[]
+    */
+    public function searchCompanyByNameOrEmailOrPhone($search): array
+    {
+        return $this->createQueryBuilder('company')
+            ->andWhere('LOWER(company.name) LIKE LOWER(:searchValue) 
+                OR LOWER(company.email) LIKE LOWER(:searchValue) 
+                OR LOWER(company.phone) LIKE LOWER(:searchValue)')
+            ->setParameter('searchValue', '%' . strtolower($search) . '%')
+            ->orderBy('company.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+    * @return Company[]
+    */
+    public function filterCompaniesByStatus($status): array
+    {
+        $queryBuilder = $this->createQueryBuilder('company')
+            ->orderBy('company.id', 'ASC');
+
+        if ($status === 'true') {
+            $queryBuilder->andWhere('company.isDeleted = :isDeleted')
+                ->setParameter('isDeleted', false);
+        } elseif ($status === 'false') {
+            $queryBuilder->andWhere('company.isDeleted = :isDeleted')
+                ->setParameter('isDeleted', true);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
     //    /**
     //     * @return Company[] Returns an array of Company objects
     //     */

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -21,6 +21,58 @@ class UserRepository extends ServiceEntityRepository
         parent::__construct($registry, User::class);
     }
 
+    /**
+    * @return User[] Returns an array of User objects
+    */
+    public function findAllUsersWithoutLoggedAdmin($loggedAdminId): array
+    {
+        return $this->createQueryBuilder('user')
+            ->andWhere('user.id != :loggedAdminId')
+            ->setParameter('loggedAdminId', $loggedAdminId)
+            ->orderBy('user.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+    * @return User[] Returns an array of User objects
+    */
+    public function searchUserByNameOrEmailOrCompanyName($loggedAdminId, $searchValue): array
+    {
+        return $this->createQueryBuilder('user')
+            ->leftJoin('user.company', 'company')
+            ->andWhere('LOWER(user.displayName) LIKE LOWER(:searchValue) 
+                OR LOWER(user.email) LIKE LOWER(:searchValue) 
+                OR LOWER(company.name) LIKE LOWER(:searchValue) ')
+            ->andWhere('user.id != :loggedAdminId')
+            ->setParameter('searchValue', '%' . strtolower($searchValue) . '%')
+            ->setParameter('loggedAdminId', $loggedAdminId)
+            ->orderBy('user.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+    * @return User[] Returns an array of User objects
+    */
+    public function filterUsersByStatus($loggedAdminId, $status): array
+    {
+        $queryBuilder = $this->createQueryBuilder('user')
+            ->andWhere('user.id != :loggedAdminId')
+            ->setParameter('loggedAdminId', $loggedAdminId)
+            ->orderBy('user.id', 'ASC');
+
+        if ($status === 'true') {
+            $queryBuilder->andWhere('user.isDeleted = :isDeleted')
+                ->setParameter('isDeleted', false);
+        } elseif ($status === 'false') {
+            $queryBuilder->andWhere('user.isDeleted = :isDeleted')
+                ->setParameter('isDeleted', true);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+    
 //    /**
 //     * @return User[] Returns an array of User objects
 //     */

--- a/src/Security/AppUserAuthenticator.php
+++ b/src/Security/AppUserAuthenticator.php
@@ -48,14 +48,14 @@ class AppUserAuthenticator extends AbstractLoginFormAuthenticator
             return new RedirectResponse($targetPath);
         }
 
+        if (in_array('ROLE_ADMIN', $token->getUser()->getRoles())) {
+            return new RedirectResponse($this->urlGenerator->generate('back_app_dashboard'));
+        }
         if (in_array('ROLE_COMPANY', $token->getUser()->getRoles())) {
             return new RedirectResponse($this->urlGenerator->generate('front_company_app_dashboard'));
         }
         if (in_array('ROLE_ACCOUNTANT', $token->getUser()->getRoles())) {
             return new RedirectResponse($this->urlGenerator->generate('front_accountant_app_dashboard'));
-        }
-        if (in_array('ROLE_ADMIN', $token->getUser()->getRoles())) {
-            return new RedirectResponse($this->urlGenerator->generate('back_app_dashboard'));
         }
         // throw new \Exception('TODO: provide a valid redirect inside ' . __FILE__);
     }

--- a/templates/_components/back/_side_bar.html.twig
+++ b/templates/_components/back/_side_bar.html.twig
@@ -2,22 +2,24 @@
 {% set dashbordPath   = path('back_app_dashboard') 			%}
 {% set settingsPath   = '#'		 							%}
 {% set logoutPath     = path('app_logout') 					%}
+{% set companyPath    = path('back_app_company_index') 		%}
+{% set userPath   	  = path('back_app_user_index') 		%}
 
 {% block body %}
 	{% if is_granted('ROLE_ADMIN') %}
 		<!-- desktop drawer -->
-		<div class="h-screen hidden md:block overflow-y-auto lg:w-80 bg-neutral-950 text-neutral-300">
+		<div class="hidden h-screen overflow-y-auto md:block lg:w-80 bg-neutral-950 text-neutral-300">
 			<div class="overflow-y-auto font-medium">
 				<div class="flex items-center mx-6 my-6">
 					<img class="object-cover w-16 h-16 rounded-full outline outline-offset-4" src="{{ vich_uploader_asset(app.user, 'imageFile') }}" alt="{{ app.user.firstname }}picture">
 					<p class="text-lg font-bold ml-6 mt-0.5 whitespace-nowrap text-ellipsis">{{ app.user.displayName }}</p>
 				</div>
-				<div class="inline-flex w-full space-x-4 px-4 mb-6">
-					<a href="{{ settingsPath }}" class="w-1/2 flex items-center px-3 py-2 text-neutral-300 hover:text-neutral-700 bg-neutral-700 rounded-xl hover:bg-gray-200 group">
+				<div class="inline-flex w-full px-4 mb-6 space-x-4">
+					<a href="{{ settingsPath }}" class="flex items-center w-1/2 px-3 py-2 text-neutral-300 hover:text-neutral-700 bg-neutral-700 rounded-xl hover:bg-gray-200 group">
 						<svg class="w-4 h-4" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M495.9 166.6c3.2 8.7 .5 18.4-6.4 24.6l-43.3 39.4c1.1 8.3 1.7 16.8 1.7 25.4s-.6 17.1-1.7 25.4l43.3 39.4c6.9 6.2 9.6 15.9 6.4 24.6c-4.4 11.9-9.7 23.3-15.8 34.3l-4.7 8.1c-6.6 11-14 21.4-22.1 31.2c-5.9 7.2-15.7 9.6-24.5 6.8l-55.7-17.7c-13.4 10.3-28.2 18.9-44 25.4l-12.5 57.1c-2 9.1-9 16.3-18.2 17.8c-13.8 2.3-28 3.5-42.5 3.5s-28.7-1.2-42.5-3.5c-9.2-1.5-16.2-8.7-18.2-17.8l-12.5-57.1c-15.8-6.5-30.6-15.1-44-25.4L83.1 425.9c-8.8 2.8-18.6 .3-24.5-6.8c-8.1-9.8-15.5-20.2-22.1-31.2l-4.7-8.1c-6.1-11-11.4-22.4-15.8-34.3c-3.2-8.7-.5-18.4 6.4-24.6l43.3-39.4C64.6 273.1 64 264.6 64 256s.6-17.1 1.7-25.4L22.4 191.2c-6.9-6.2-9.6-15.9-6.4-24.6c4.4-11.9 9.7-23.3 15.8-34.3l4.7-8.1c6.6-11 14-21.4 22.1-31.2c5.9-7.2 15.7-9.6 24.5-6.8l55.7 17.7c13.4-10.3 28.2-18.9 44-25.4l12.5-57.1c2-9.1 9-16.3 18.2-17.8C227.3 1.2 241.5 0 256 0s28.7 1.2 42.5 3.5c9.2 1.5 16.2 8.7 18.2 17.8l12.5 57.1c15.8 6.5 30.6 15.1 44 25.4l55.7-17.7c8.8-2.8 18.6-.3 24.5 6.8c8.1 9.8 15.5 20.2 22.1 31.2l4.7 8.1c6.1 11 11.4 22.4 15.8 34.3zM256 336a80 80 0 1 0 0-160 80 80 0 1 0 0 160z"/></svg>
 						<p class="ml-2 whitespace-nowrap">Paramètres</p>
 					</a>
-					<a href="{{ logoutPath }}" class="w-1/2 flex items-center px-3 py-2 outline outline-neutral-700 hover:outline-none -outline-offset-2 rounded-xl hover:bg-gray-200 group">
+					<a href="{{ logoutPath }}" class="flex items-center w-1/2 px-3 py-2 outline outline-neutral-700 hover:outline-none -outline-offset-2 rounded-xl hover:bg-gray-200 group">
 						<svg class="w-4 h-4 text-neutral-700" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128zM160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0z"/></svg>
 						<p class="ml-2 whitespace-nowrap text-neutral-700">Déconnexion</p>
 					</a>
@@ -34,11 +36,35 @@
 						</a>
 					</li>
 				</ul>	
+				<ul>
+					<li>
+						<a href="{{ companyPath }}" class="flex items-center p-4 mx-4 rounded-xl hover:bg-neutral-300 hover:text-neutral-700 active:bg-neutral-700 group">
+							<svg 
+								class="w-6 h-6 transition duration-75" fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="16" width="18" aria-hidden="true" viewbox="0 0 576 512">
+								<!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+								<path d="M48 0C21.5 0 0 21.5 0 48V464c0 26.5 21.5 48 48 48h96V432c0-26.5 21.5-48 48-48s48 21.5 48 48v80h96c26.5 0 48-21.5 48-48V48c0-26.5-21.5-48-48-48H48zM64 240c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V240zm112-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V240c0-8.8 7.2-16 16-16zm80 16c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H272c-8.8 0-16-7.2-16-16V240zM80 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16zm80 16c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V112zM272 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H272c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16z"/>
+							</svg>
+							<p class="ms-4 whitespace-nowrap">Company</p>
+						</a>
+					</li>
+				</ul>	
+				<ul>
+					<li>
+						<a href="{{ userPath }}" class="flex items-center p-4 mx-4 rounded-xl hover:bg-neutral-300 hover:text-neutral-700 active:bg-neutral-700 group">
+							<svg
+								class="w-6 h-6 transition duration-75" fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="16" width="18" aria-hidden="true" viewbox="0 0 576 512">
+								<!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.-->
+								<path d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H512c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm80 256h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm-32-96a64 64 0 1 1 128 0 64 64 0 1 1 -128 0zm256-32H496c8.8 0 16 7.2 16 16s-7.2 16-16 16H368c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H496c8.8 0 16 7.2 16 16s-7.2 16-16 16H368c-8.8 0-16-7.2-16-16s7.2-16 16-16zm0 64H496c8.8 0 16 7.2 16 16s-7.2 16-16 16H368c-8.8 0-16-7.2-16-16s7.2-16 16-16z"/>
+							</svg>
+							<p class="ms-4 whitespace-nowrap">Utilisateurs</p>
+						</a>
+					</li>
+				</ul>	
 			</div>
 		</div>
 
 		<!-- burger nav mobile -->
-		<aside class="relative flex justify-center text-neutral-300 flex-shrink-0 h-12 md:hidden bg-neutral-950">
+		<aside class="relative flex justify-center flex-shrink-0 h-12 text-neutral-300 md:hidden bg-neutral-950">
 			<button id="drawer-navigation-button" class="absolute right-0" type="button" data-drawer-target="drawer-navigation" data-drawer-show="drawer-navigation" aria-controls="drawer-navigation">
 				<svg class="w-6 h-6 mt-3 me-4" fill="currentColor" xmlns="http://www.w3.org/2000/svg" height="16" width="14" viewbox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>
 			</button>
@@ -61,14 +87,14 @@
 					<p class="text-lg font-bold ml-6 mt-0.5 whitespace-nowrap text-ellipsis">{{ app.user.displayName }}</p>
 				</div>
 				
-				<div class="inline-flex w-full space-x-4 px-4 my-3">
-					<a href="{{ settingsPath }}" class="w-1/2 flex items-center px-3 py-2 text-neutral-300 hover:text-neutral-700 bg-neutral-700 rounded-xl hover:bg-gray-200 group">
+				<div class="inline-flex w-full px-4 my-3 space-x-4">
+					<a href="{{ settingsPath }}" class="flex items-center w-1/2 px-3 py-2 text-neutral-300 hover:text-neutral-700 bg-neutral-700 rounded-xl hover:bg-gray-200 group">
 						<svg class="w-4 h-4" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M495.9 166.6c3.2 8.7 .5 18.4-6.4 24.6l-43.3 39.4c1.1 8.3 1.7 16.8 1.7 25.4s-.6 17.1-1.7 25.4l43.3 39.4c6.9 6.2 9.6 15.9 6.4 24.6c-4.4 11.9-9.7 23.3-15.8 34.3l-4.7 8.1c-6.6 11-14 21.4-22.1 31.2c-5.9 7.2-15.7 9.6-24.5 6.8l-55.7-17.7c-13.4 10.3-28.2 18.9-44 25.4l-12.5 57.1c-2 9.1-9 16.3-18.2 17.8c-13.8 2.3-28 3.5-42.5 3.5s-28.7-1.2-42.5-3.5c-9.2-1.5-16.2-8.7-18.2-17.8l-12.5-57.1c-15.8-6.5-30.6-15.1-44-25.4L83.1 425.9c-8.8 2.8-18.6 .3-24.5-6.8c-8.1-9.8-15.5-20.2-22.1-31.2l-4.7-8.1c-6.1-11-11.4-22.4-15.8-34.3c-3.2-8.7-.5-18.4 6.4-24.6l43.3-39.4C64.6 273.1 64 264.6 64 256s.6-17.1 1.7-25.4L22.4 191.2c-6.9-6.2-9.6-15.9-6.4-24.6c4.4-11.9 9.7-23.3 15.8-34.3l4.7-8.1c6.6-11 14-21.4 22.1-31.2c5.9-7.2 15.7-9.6 24.5-6.8l55.7 17.7c13.4-10.3 28.2-18.9 44-25.4l12.5-57.1c2-9.1 9-16.3 18.2-17.8C227.3 1.2 241.5 0 256 0s28.7 1.2 42.5 3.5c9.2 1.5 16.2 8.7 18.2 17.8l12.5 57.1c15.8 6.5 30.6 15.1 44 25.4l55.7-17.7c8.8-2.8 18.6-.3 24.5 6.8c8.1 9.8 15.5 20.2 22.1 31.2l4.7 8.1c6.1 11 11.4 22.4 15.8 34.3zM256 336a80 80 0 1 0 0-160 80 80 0 1 0 0 160z"/></svg>
-						<p class="ml-2 whitespace-nowrap text-sm">Paramètres</p>
+						<p class="ml-2 text-sm whitespace-nowrap">Paramètres</p>
 					</a>
-					<a href="{{ logoutPath }}" class="w-1/2 flex items-center px-3 py-2 outline outline-neutral-700 hover:outline-none -outline-offset-2 rounded-xl hover:bg-gray-200 group">
+					<a href="{{ logoutPath }}" class="flex items-center w-1/2 px-3 py-2 outline outline-neutral-700 hover:outline-none -outline-offset-2 rounded-xl hover:bg-gray-200 group">
 						<svg class="w-4 h-4 text-neutral-700" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128zM160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0z"/></svg>
-						<p class="ml-2 whitespace-nowrap text-sm text-neutral-700">Déconnexion</p>
+						<p class="ml-2 text-sm whitespace-nowrap text-neutral-700">Déconnexion</p>
 					</a>
 				</div>
 				

--- a/templates/_components/back/company/_form.html.twig
+++ b/templates/_components/back/company/_form.html.twig
@@ -1,0 +1,10 @@
+{{ form_start(form) }}
+
+{{ form_row(form.name,      { label: 'Nom',                 attr: { placeholder: 'Clickbill' }}) }}
+{{ form_row(form.email,     { label: 'Email',               attr: { placeholder: 'sarah.tartuf@gmail.com' } }) }}
+{{ form_row(form.phone,     { label: 'Numéro de téléphone', attr: { placeholder: '06XXXXXXXX' } }) }}
+{{ form_row(form.address,   { label: 'Adresse',             attr: { placeholder: '4 rue des abricot 77800 Jean-sur-Place' } }) }}
+
+<button type="submit" class="primaryButton">{{ button_label }}</button>
+
+{{ form_end(form) }}

--- a/templates/_components/back/company/_table.html.twig
+++ b/templates/_components/back/company/_table.html.twig
@@ -1,0 +1,89 @@
+<div class="relative my-6 overflow-x-auto ">
+	<table class="w-full text-sm text-left text-neutral-500 rtl:text-right dark:text-neutral-400">
+		<thead class="text-xs uppercase border-t border-b text-neutral-700 border-neutral-200 dark:border-neutral-400 bg-neutral-100 dark:bg-neutral-700 dark:text-neutral-400">
+			<tr>
+				<th scope="col" class="px-6 py-3">
+					Company
+				</th>
+				<th scope="col" class="px-6 py-3">
+					Adresse
+				</th>
+                <th scope="col" class="px-6 py-3">
+					Téléphone
+				</th>
+                <th scope="col" class="px-6 py-3">
+					Email
+				</th>
+				<th scope="col" class="px-6 py-3">
+					Statut
+				</th>
+				<th scope="col" class="px-6 py-3"></th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for company in companies %}
+				<tr class="bg-white border-b hover:bg-neutral-100 dark:hover:bg-neutral-700 dark:bg-neutral-800 dark:border-neutral-700">
+					<th scope="row" class="px-6 py-4 font-medium whitespace-nowrap dark:text-white">
+						<span>{{ company.name }}</span>
+					</th>
+					<td class="px-6 py-4">
+						{{ company.address }}
+					</td>
+					<td class="px-6 py-4">
+						{{ company.phone }}
+					</td>
+                    <td class="px-6 py-4">
+						{{ company.email }}
+					</td>
+					{% if company.isDeleted %}
+						<td class="px-6 py-4 text-red-500">
+							Inactif
+						</td>
+					{% else %}
+						<td class="px-6 py-4 text-green-500">
+							Actif
+						</td>
+					{% endif %}
+					<td class="text-lg font-medium text-center dark:text-white">
+						<button id="dropdownHoverCompany" data-dropdown-toggle="dropdownHoverCompany{{company.id}}" data-dropdown-trigger="click" class="p-3" type="button">
+							<svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M64 360a56 56 0 1 0 0 112 56 56 0 1 0 0-112zm0-160a56 56 0 1 0 0 112 56 56 0 1 0 0-112zM120 96A56 56 0 1 0 8 96a56 56 0 1 0 112 0z"/></svg>
+						</button>
+					</td>
+				</tr>
+			{% else %}
+				<tr>
+					<td colspan="11">Aucun company trouvé</td>
+				</tr>
+			{% endfor %}
+		</tbody>
+	</table>
+</div>
+
+<!-- Company Dropdown menu -->
+{% for company in companies %}
+	<div id="dropdownHoverCompany{{company.id}}" class="z-10 hidden bg-white divide-y rounded-lg shadow divide-neutral-100 w-44 dark:bg-neutral-700">
+		<ul class="py-2 text-sm text-neutral-700 dark:text-neutral-200" aria-labelledby="dropdownHoverButton">
+			<li>
+				<a href="{{ path('back_app_company_show', {'id': company.id}) }}" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white">Détails</a>
+			</li>
+            <li>
+                <a href="{{ path('back_app_company_edit', {'id': company.id}) }}" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white">Modifier</a>
+            </li>
+			{% if company.isDeleted %}
+				<li>
+					<form method="post" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white" action="{{ path('back_app_company_enable', {'id': company.id}) }}" onsubmit="return confirm('Vous êtes sûr de vouloir activer cette Company ?');">
+						<input type="hidden" name="_token" value="{{ csrf_token('enable' ~ company.id) }}">
+						<button class="font-bold text-green-600 btn">Activer</button>
+					</form>	
+				</li>
+			{% else %}
+				<li>
+					<form method="post" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white" action="{{ path('back_app_company_delete', {'id': company.id}) }}" onsubmit="return confirm('Vous êtes sûr de vouloir supprimer cette Company ?');">
+						<input type="hidden" name="_token" value="{{ csrf_token('delete' ~ company.id) }}">
+						<button class="font-bold text-red-600 btn">Supprimer</button>
+					</form>	
+				</li>
+			{% endif %}
+		</ul>
+	</div>
+{% endfor %}

--- a/templates/_components/back/user/_form.html.twig
+++ b/templates/_components/back/user/_form.html.twig
@@ -1,0 +1,11 @@
+{{ form_start(form) }}
+
+{{ form_row(form.firstName, { label: 'Nom',                 attr: { placeholder: 'Marius' } }) }}
+{{ form_row(form.lastName,  { label: 'Prénom',              attr: { placeholder: 'Kellogs' } }) }}
+{{ form_row(form.email,     { label: 'Email',               attr: { placeholder: 'marius.kellogs@gmail.com' } }) }}
+{{ form_row(form.company,   { label: 'Company' }) }}
+{{ form_row(form.role,      { label: 'Role' }) }}
+
+<button type="submit" class="primaryButton">{{ button_label }}</button>
+
+{{ form_end(form) }}

--- a/templates/_components/back/user/_table.html.twig
+++ b/templates/_components/back/user/_table.html.twig
@@ -1,0 +1,104 @@
+<div class="relative my-6 overflow-x-auto ">
+	<table class="w-full text-sm text-left text-neutral-500 rtl:text-right dark:text-neutral-400">
+		<thead class="text-xs uppercase border-t border-b text-neutral-700 border-neutral-200 dark:border-neutral-400 bg-neutral-100 dark:bg-neutral-700 dark:text-neutral-400">
+			<tr>
+				<th scope="col" class="px-6 py-3">
+					Nom
+				</th>
+				<th scope="col" class="px-6 py-3">
+					Email
+				</th>
+                <th scope="col" class="px-6 py-3">
+					Role
+				</th>
+                <th scope="col" class="px-6 py-3">
+					Company
+				</th>
+				<th scope="col" class="px-6 py-3">
+					Statut
+				</th>
+				<th scope="col" class="px-6 py-3"></th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for user in users %}
+				{% if 'ROLE_ADMIN' in user.roles %}
+					{% set highestRole = 'Admin' %}
+				{% elseif 'ROLE_COMPANY' in user.roles %}
+					{% set highestRole = 'Entreprise' %}
+				{% elseif 'ROLE_ACCOUNTANT' in user.roles %}
+					{% set highestRole = 'Comptable' %}
+				{% else %}
+					{% set highestRole = 'Aucun' %}
+				{% endif %}
+				<tr class="bg-white border-b hover:bg-neutral-100 dark:hover:bg-neutral-700 dark:bg-neutral-800 dark:border-neutral-700">
+					<th scope="row" class="px-6 py-4 font-medium whitespace-nowrap dark:text-white">
+						<span>{{ user.displayName }}</span>
+					</th>
+					<td class="px-6 py-4">
+						{{ user.email }}
+					</td>
+					<td class="px-6 py-4">
+						{{ highestRole }}
+					</td>
+                    <td class="px-6 py-4">
+						{{ user.company }}
+					</td>
+					{% if user.isDeleted %}
+						<td class="px-6 py-4 text-red-500">
+							Inactif
+						</td>
+					{% else %}
+						<td class="px-6 py-4 text-green-500">
+							Actif
+						</td>
+					{% endif %}
+					<td class="text-lg font-medium text-center dark:text-white">
+						<button id="dropdownHoverUser" data-dropdown-toggle="dropdownHoverUser{{user.id}}" data-dropdown-trigger="click" class="p-3" type="button">
+							<svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M64 360a56 56 0 1 0 0 112 56 56 0 1 0 0-112zm0-160a56 56 0 1 0 0 112 56 56 0 1 0 0-112zM120 96A56 56 0 1 0 8 96a56 56 0 1 0 112 0z"/></svg>
+						</button>
+					</td>
+				</tr>
+			{% else %}
+				<tr>
+					<td colspan="11">Aucun utilisateur trouvé</td>
+				</tr>
+			{% endfor %}
+		</tbody>
+	</table>
+</div>
+
+<!-- Company Dropdown menu -->
+{% for user in users %}
+	<div id="dropdownHoverUser{{user.id}}" class="z-10 hidden bg-white divide-y rounded-lg shadow divide-neutral-100 w-44 dark:bg-neutral-700">
+		<ul class="py-2 text-sm text-neutral-700 dark:text-neutral-200" aria-labelledby="dropdownHoverButton">
+			<li>
+				<a href="{{ path('back_app_user_show', {'id': user.id}) }}" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white">Détails</a>
+			</li>
+            <li>
+                <a href="{{ path('back_app_user_edit', {'id': user.id}) }}" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white">Modifier</a>
+            </li>
+			{% if user.isDeleted %}
+				<li>
+					<form method="post" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white" action="{{ path('back_app_user_enable', {'id': user.id}) }}" onsubmit="return confirm('Vous êtes sûr de vouloir réactiver cet utilisateur ?');">
+						<input type="hidden" name="_token" value="{{ csrf_token('enable' ~ user.id) }}">
+						<button class="font-bold text-green-600 btn">Activer</button>
+					</form>	
+				</li>
+			{% else %}
+				<li>
+					<form method="post" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white" action="{{ path('back_app_user_send_mail', {'id': user.id}) }}" onsubmit="return confirm('Vous êtes sûr de vouloir envoyer un mail de connexion à cet utilisateur ?');">
+						<input type="hidden" name="_token" value="{{ csrf_token('send_mail' ~ user.id) }}">
+						<button class="font-bold btn">Mail de connexion</button>
+					</form>	
+				</li>
+				<li>
+					<form method="post" class="block px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-600 dark:hover:text-white" action="{{ path('back_app_user_delete', {'id': user.id}) }}" onsubmit="return confirm('Vous êtes sûr de vouloir supprimer cet utilisateur ?');">
+						<input type="hidden" name="_token" value="{{ csrf_token('delete' ~ user.id) }}">
+						<button class="font-bold text-red-600 btn">Supprimer</button>
+					</form>	
+				</li>
+			{% endif %}
+		</ul>
+	</div>
+{% endfor %}

--- a/templates/_components/front/global/_side_bar.html.twig
+++ b/templates/_components/front/global/_side_bar.html.twig
@@ -200,7 +200,7 @@
 					<li>
 						<div href="#" class="flex items-center px-3 py-4 mx-4 rounded-xl hover:bg-gray-200 group dark:hover:bg-neutral-800 dark:hover:text-neutral-300800">
 							<label class="relative inline-flex items-center cursor-pointer">
-								<input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer">
+								<input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer darkmode-checkbox">
 								<div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer dark:bg-neutral-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-neutral-600 peer-checked:bg-amberYellow dark:peer-checked:bg-amberYellowDarker"></div>
 							</label>
 							<p class="ms-4 whitespace-nowrap">Thème sombre</p>
@@ -357,7 +357,7 @@
 					<li>
 						<div href="#" class="flex items-center px-3 py-4 mx-4 rounded-xl hover:bg-gray-200 group dark:hover:bg-neutral-800 dark:hover:text-neutral-300">
 							<label class="relative inline-flex items-center cursor-pointer">
-								<input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer">
+								<input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer darkmode-checkbox">
 								<div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer dark:bg-neutral-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-neutral-600 peer-checked:bg-amberYellow dark:peer-checked:bg-amberYellowDarker"></div>
 							</label>
 							<p class="ms-4 whitespace-nowrap">Thème sombre</p>

--- a/templates/back/company/edit.html.twig
+++ b/templates/back/company/edit.html.twig
@@ -1,0 +1,14 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}Edit Company Admin{% endblock %}
+
+{% block content %}
+    <a href="{{ path('back_app_company_index') }}" class="backToPrevious">
+        <svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+    </a>
+    <h1 class="pageTitle">Modifier une Company</h1>
+
+    <div class="mx-auto md:w-1/2 lg:mx-0">
+        {{ include('_components/back/company/_form.html.twig', { 'button_label': 'Modifier' }, ) }}
+    </div>
+{% endblock %}

--- a/templates/back/company/index.html.twig
+++ b/templates/back/company/index.html.twig
@@ -1,0 +1,26 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}
+    Admin Company
+{% endblock %}
+
+{% block content %}
+    <h1 class="pageTitle">Liste des companys</h1>
+    {% for error in errors %}
+        {{ include('_components/front/global/_toast.html.twig', {
+        'message' : error, 
+        'state' : 'error'} ) }}
+    {% endfor %}
+    {% for succes in success %}
+        {{ include('_components/front/global/_toast.html.twig', {
+            'message' : succes, 
+            'state' : 'sucess'} ) }}
+    {% endfor %}
+
+    {{ include('front/search/index.html.twig') }}
+    
+    <a href="{{ path('back_app_company_new')}}" class="primaryButton">
+		Créer company
+	</a>
+    {{ include('_components/back/company/_table.html.twig', companies) }}
+{% endblock %}

--- a/templates/back/company/new.html.twig
+++ b/templates/back/company/new.html.twig
@@ -1,0 +1,14 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}New Company Admin{% endblock %}
+
+{% block content %}
+	<a href="{{ path('back_app_company_index') }}" class="backToPrevious">
+		<svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+	</a>
+	<h1 class="pageTitle">Ajouter une nouvelle company</h1>
+
+	<div class="mx-auto md:w-1/2 lg:mx-0">
+		{{ include('_components/back/company/_form.html.twig', { 'button_label': 'Ajouter' }, ) }}
+	</div>
+{% endblock %}

--- a/templates/back/company/show.html.twig
+++ b/templates/back/company/show.html.twig
@@ -1,0 +1,47 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}Company Admin Info{% endblock %}
+
+{% block content %}
+    <a href="{{ path('back_app_company_index') }}" class="backToPrevious">
+		<svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+	</a>
+    <h1 class="pageTitle">
+        Company : {{ company.name }}
+    </h1>
+    <table class="table w-9/12 table-auto md:w-3/12">
+		<tbody class="text-left">
+			<tr>
+				<th>Adresse</th>
+				<td>{{ company.address }}</td>
+			</tr>
+            <tr>
+				<th>Email</th>
+				<td>{{ company.email }}</td>
+			</tr>
+            <tr>
+				<th>Téléphone</th>
+				<td>{{ company.phone }}</td>
+			</tr>
+			<tr>
+				<th>Créée le</th>
+				<td>{{ company.createdAt ? company.createdAt|date('d/m/Y') : '' }}</td>
+			</tr>
+			<tr>
+				<th>Créée par</th>
+				<td>{{ created_by.name }}</td>
+			</tr>
+		</tbody>
+	</table>
+
+    <div class="inline-flex flex-wrap justify-center my-3 space-y-3 md:justify-end md:items-center md:space-y-0 md:space-x-3">
+		<a href="{{ path('back_app_company_edit', {'id': company.id}) }}">
+			<button type="button" class="primaryButton">Modifier</button>
+		</a>
+		{{ include('_components/front/global/_delete_form.html.twig',{
+			'path': 'back_app_company_delete',
+			'type': 'id',
+			'id': company.id,
+		})}}
+	</div>
+{% endblock %}

--- a/templates/back/default/dashboard.html.twig
+++ b/templates/back/default/dashboard.html.twig
@@ -1,7 +1,7 @@
 {% extends 'layout/back_office.html.twig' %}
 
-{% block title %}BackOffice{% endblock %}
+{% block title %}Admin Dashboard{% endblock %}
 
 {% block content %}
-<h1 class="pageTitle">Bienvenue sur le back office</h1>
+    <h1 class="pageTitle">Dashboard admin</h1>
 {% endblock %}

--- a/templates/back/user/edit.html.twig
+++ b/templates/back/user/edit.html.twig
@@ -1,0 +1,14 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}Admin Edit User{% endblock %}
+
+{% block content %}
+    <a href="{{ path('back_app_user_index') }}" class="backToPrevious">
+        <svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+    </a>
+    <h1 class="pageTitle">Modifier un utilisateur</h1>
+
+    <div class="mx-auto md:w-1/2 lg:mx-0">
+        {{ include('_components/back/user/_form.html.twig', { 'button_label': 'Modifier' }, ) }}
+    </div>
+{% endblock %}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -1,0 +1,24 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}Admin User{% endblock %}
+
+{% block content %}
+    <h1 class="pageTitle">Liste des utilisateurs</h1>
+    {% for error in errors %}
+        {{ include('_components/front/global/_toast.html.twig', {
+        'message' : error, 
+        'state' : 'error'} ) }}
+    {% endfor %}
+    {% for succes in success %}
+        {{ include('_components/front/global/_toast.html.twig', {
+            'message' : succes, 
+            'state' : 'sucess'} ) }}
+    {% endfor %}
+
+    {{ include('front/search/index.html.twig') }}
+    
+    <a href="{{ path('back_app_user_new')}}" class="primaryButton">
+		Créer utilisateur
+	</a>
+    {{ include('_components/back/user/_table.html.twig', users) }}
+{% endblock %}

--- a/templates/back/user/new.html.twig
+++ b/templates/back/user/new.html.twig
@@ -1,0 +1,14 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}New User{% endblock %}
+
+{% block content %}
+    <a href="{{ path('back_app_user_index') }}" class="backToPrevious">
+        <svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+    </a>
+    <h1 class="pageTitle">Créer un utilisateur</h1>
+
+    <div class="mx-auto md:w-1/2 lg:mx-0">
+        {{ include('_components/back/user/_form.html.twig', { 'button_label': 'Ajouter' }, ) }}
+    </div>
+{% endblock %}

--- a/templates/back/user/show.html.twig
+++ b/templates/back/user/show.html.twig
@@ -1,0 +1,56 @@
+{% extends 'layout/back_office.html.twig' %}
+
+{% block title %}User Admin Info{% endblock %}
+
+{% block content %}
+    {% if 'ROLE_ADMIN' in user.roles %}
+        {% set highestRole = 'Admin' %}
+    {% elseif 'ROLE_COMPANY' in user.roles %}
+        {% set highestRole = 'Entreprise' %}
+    {% elseif 'ROLE_ACCOUNTANT' in user.roles %}
+        {% set highestRole = 'Comptable' %}
+    {% else %}
+        {% set highestRole = 'Aucun' %}
+    {% endif %}
+    <a href="{{ path('back_app_user_index') }}" class="backToPrevious">
+		<svg class="w-6 h-6" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l128 128c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 73.4-73.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-128 128z"/></svg>
+	</a>
+    <h1 class="pageTitle">
+        Utilisateur : {{ user.displayName }}
+    </h1>
+    <table class="table w-9/12 table-auto md:w-3/12">
+		<tbody class="text-left">
+			<tr>
+				<th>Company</th>
+				<td>{{ user.company.name }}</td>
+			</tr>
+            <tr>
+				<th>Role</th>
+				<td>{{ highestRole }}</td>
+			</tr>
+            <tr>
+				<th>Email</th>
+				<td>{{ user.email }}</td>
+			</tr>
+			<tr>
+				<th>Créée le</th>
+				<td>{{ user.createdAt ? user.createdAt|date('d/m/Y') : '' }}</td>
+			</tr>
+			<tr>
+				<th>Créée par</th>
+				<td>{{ created_by.name }}</td>
+			</tr>
+		</tbody>
+	</table>
+
+    <div class="inline-flex flex-wrap justify-center my-3 space-y-3 md:justify-end md:items-center md:space-y-0 md:space-x-3">
+		<a href="{{ path('back_app_user_edit', {'id': user.id}) }}">
+			<button type="button" class="primaryButton">Modifier</button>
+		</a>
+		{{ include('_components/front/global/_delete_form.html.twig',{
+			'path': 'back_app_user_delete',
+			'type': 'id',
+			'id': user.id,
+		})}}
+	</div>
+{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -20,10 +20,14 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.0/flowbite.min.js"></script>
         
         <script>
+            let checkboxes = document.querySelectorAll('.darkmode-checkbox');
             if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
                 document.documentElement.classList.add('dark');
+                checkboxes.forEach(function(checkbox) {
+                    checkbox.checked = true;
+                })
             } else {
-                document.documentElement.classList.remove('dark')
+                document.documentElement.classList.remove('dark');
             }
 
             function toggleDarkMode() {

--- a/templates/emails/new_account.html.twig
+++ b/templates/emails/new_account.html.twig
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Votre nouveau compte Clickbill</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+        }
+
+        body {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: #fff;
+        }
+        
+        .container {
+            width: 100%;
+            max-width: 600px;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+
+        .inner-container {
+            width: 80%;
+            max-width: 600px;
+            text-align: center;
+            background-color: rgb(255 255 255 / 1);
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+        }
+        
+        .btn-container {
+            display: flex;
+            justify-content: center;
+            margin-top: 20px;
+        }
+
+        .btn {
+            flex: 1;
+            padding: 10px 20px;
+            margin: 0 5px;
+            border-radius: 5px;
+            text-decoration: none;
+            color: black;
+            font-weight: bold;
+            cursor: pointer;
+        }
+
+        .btn-yellow {
+            background-color: #F6C31E;
+        }
+
+        .btn-yellow:hover {
+            background-color: rgb(234 179 8);
+        }
+        
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="inner-container">
+            <h2>Votre nouveau compte Clickbill</h2>
+            <p>Votre nouveau compte à bien été créer, vous pouvez maintenant commencer à gérer les devis et les factures de votre entreprise !</p>
+            <div>
+                <p>Email de connexion : <strong>{{ loginEmail }}</strong></p>
+                <p>Mot de passe : <strong>{{ loginPassword }}</strong></p>
+            </div>
+            <p>Vous pouvez vous connectez dès à présent en cliquant sur le bouton suivant : </p>
+            <div class="btn-container">
+                <a href="{{loginUrl}}" class="btn btn-yellow">Me connecter</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/front/search/index.html.twig
+++ b/templates/front/search/index.html.twig
@@ -19,7 +19,7 @@
 		</div>
 
 		{% if form_errors(searchForm.search) %}
-			<div class="text-red-500 text-xs mt-1">{{ form_errors(searchForm.search) }}</div>
+			<div class="mt-1 text-xs text-red-500">{{ form_errors(searchForm.search) }}</div>
 		{% endif %}
 		{{ form_end(searchForm) }}
 	</div>
@@ -28,11 +28,25 @@
 {# Get Selected option value #}
 <script>
 	document.addEventListener('DOMContentLoaded', function () {
-		var elementName = document.getElementById('filter-select').name
+		let elementId;
+		const elementName = document.getElementById('filter-select').name;
 
-		var elementId = elementName == 'status_filter' ? 'status_filter_status' : elementName == 'category_filter' ? 'category_filter_category' : 'bill_filter_status'
+		// Add here more tuple in case we add another filters
+		const elements = [
+			['status_filter', 'status_filter_status'],
+			['category_filter', 'category_filter_category'],
+			['bill_filter', 'bill_filter_status'],
+			['quote_filter', 'quote_filter_status'],
+			['admin_filter', 'admin_filter_status']
+		];
 
-		console.log('test', elementName)
+		elements.forEach(tuple => {
+			if (tuple[0] === elementName) {
+				elementId = tuple[1];
+			}
+		});
+
+		console.log('test', elementName);
 
 		const selectStatus = document.getElementById(elementId);
 		selectStatus.addEventListener('change', function () {

--- a/templates/front/user/index.html.twig
+++ b/templates/front/user/index.html.twig
@@ -9,7 +9,7 @@
 
     <div class="flex mb-4">
         <label class="relative inline-flex items-center cursor-pointer">
-            <input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer">
+            <input type="checkbox" onclick="toggleDarkMode()" value="true" class="sr-only peer darkmode-checkbox">
             <div class="w-11 h-6 bg-gray-300 peer-focus:outline-none rounded-full peer dark:bg-neutral-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-neutral-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-neutral-600 peer-checked:bg-amberYellow dark:peer-checked:bg-amberYellowDarker"></div>
         </label>
         <p class="ms-4 whitespace-nowrap">Thème sombre</p>

--- a/templates/layout/back_office.html.twig
+++ b/templates/layout/back_office.html.twig
@@ -7,4 +7,9 @@
         {% block content %}{% endblock %}
     </section>
 </main>
+<script>
+    // Set dark mode for admin side only.
+    document.documentElement.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+</script>
 {% endblock %}


### PR DESCRIPTION
### Nouveau (CRUD Utilisateur)

- Possibilité de créer/modifier/supprimer(soft) un utilisateur.
- Possibilité de réactiver un utilisateur (reverse du soft delete).
- Envoi d'email de connexion (reset mot de passe à chaque fois car une fois hashé impossible d'envoyer un mot de passe lisible de toute façon c'est pour une première connexion).
- Filtre par Status (Actif / Inactif) (isDelete).
- Filtre par Recherche (Nom / Nom de Company / Email).

### Nouveau (CRUD Company)

- Possibilité de créer/modifier/supprimer(soft) une company.
- Possibilité de réactiver une company (reverse du soft delete).
- Filtre par Status (Actif / Inactif) (isDelete).
- Filtre par Recherche (Nom / Email / Téléphone).

### Fixes

- Fix du bouton dark mode dans le cas où le dark mode est déjà activer.
- Ajustement de la vérification des routes dans le cas où on est connecter en tant qu'Admin.
- Ajustement du script JS pour la recherche par status pour le rendre plus facile d'utilisation.
- Fix au niveau des fixtures (Des erreurs sont toujours existantes).

### Notes

- Je remarque a l'heure où j'écris cette PR que je n'ai pas utiliser de slug/guid ou autre pour les company & user. Hésitez pas à me préciser lequel serais le mieux à utiliser pour chaque.